### PR TITLE
[Android] Replaced 'getCurrentActivity' with 'getReactApplicationContext'

### DIFF
--- a/android/src/main/java/com/evollu/react/fa/FIRAnalyticsModule.java
+++ b/android/src/main/java/com/evollu/react/fa/FIRAnalyticsModule.java
@@ -28,22 +28,22 @@ public class FIRAnalyticsModule extends ReactContextBaseJavaModule implements Li
 
     @ReactMethod
     public void setUserId(String id){
-        FirebaseAnalytics.getInstance(getCurrentActivity()).setUserId(id);
+        FirebaseAnalytics.getInstance(getReactApplicationContext()).setUserId(id);
     }
 
     @ReactMethod
     public void setUserProperty(String name, String property) {
-        FirebaseAnalytics.getInstance(getCurrentActivity()).setUserProperty(name, property);
+        FirebaseAnalytics.getInstance(getReactApplicationContext()).setUserProperty(name, property);
     }
 
     @ReactMethod
     public void logEvent(String name, ReadableMap parameters) {
-        FirebaseAnalytics.getInstance(getCurrentActivity()).logEvent(name, Arguments.toBundle(parameters));
+        FirebaseAnalytics.getInstance(getReactApplicationContext()).logEvent(name, Arguments.toBundle(parameters));
     }
 
     @ReactMethod
     public void setEnabled(Boolean enabled) {
-        FirebaseAnalytics.getInstance(getCurrentActivity()).setAnalyticsCollectionEnabled(enabled);
+        FirebaseAnalytics.getInstance(getReactApplicationContext()).setAnalyticsCollectionEnabled(enabled);
     }
 
     @Override


### PR DESCRIPTION
Replaced `getCurrentActivity()` with `getReactApplicationContext()` for all methods in android module, because you can call analytics methods before the app will be initialized (getCurrentActivity returns null in this case and the app crashing)
