### PR TITLE
Do not abort build on lint error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,10 @@ android {
         versionCode 1
         versionName "1.0"
     }
+    
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Trying to build an app with a dependency on react-native-firebase-analytics fails during `./gradlew build` due to linting errors in react-native-firebase-analytics.

This change fixes that problem.
