### PR TITLE
Support the setScreenName method

### DIFF
--- a/android/src/main/java/com/evollu/react/fa/FIRAnalyticsModule.java
+++ b/android/src/main/java/com/evollu/react/fa/FIRAnalyticsModule.java
@@ -42,6 +42,11 @@ public class FIRAnalyticsModule extends ReactContextBaseJavaModule implements Li
     }
 
     @ReactMethod
+    public void setScreenName(String name) {
+        FirebaseAnalytics.getInstance(getReactApplicationContext()).setScreenName(name);
+    }
+
+    @ReactMethod
     public void setEnabled(Boolean enabled) {
         FirebaseAnalytics.getInstance(getReactApplicationContext()).setAnalyticsCollectionEnabled(enabled);
     }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ class FA {
         FIRAnalytics.logEvent(name, parameters);
     }
 
+    static setScreenName(name) {
+        FIRAnalytics.setScreenName(name);
+    }
+
     static setEnabled(enabled) {
         FIRAnalytics.setEnabled(enabled);
     }

--- a/ios/RNFIRAnalytics.m
+++ b/ios/RNFIRAnalytics.m
@@ -37,6 +37,11 @@ RCT_EXPORT_METHOD(logEvent: (NSString*)name property: (NSDictionary*)parameters)
   [FIRAnalytics logEventWithName:name parameters:parameters];
 }
 
+RCT_EXPORT_METHOD(setScreenName: (NSString*)name)
+{
+  [FIRAnalytics setScreenName:name screenClass:nil];
+}
+
 RCT_EXPORT_METHOD(setEnabled: (BOOL)enabled)
 {
   [[FIRAnalyticsConfiguration sharedInstance] setAnalyticsCollectionEnabled:enabled];


### PR DESCRIPTION
https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#/c:objc(cs)FIRAnalytics(cm)setScreenName:screenClass:

Tested on iOS but not android.