### PR TITLE
Remove createJSModules @overide marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/evollu/react/fa/FIRAnalyticsPackage.java
+++ b/android/src/main/java/com/evollu/react/fa/FIRAnalyticsPackage.java
@@ -24,7 +24,7 @@ public class FIRAnalyticsPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/evollu/react/fa/FIRAnalyticsPackage.java
+++ b/android/src/main/java/com/evollu/react/fa/FIRAnalyticsPackage.java
@@ -24,7 +24,7 @@ public class FIRAnalyticsPackage implements ReactPackage {
         return modules;
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/evollu/react/fa/FIRAnalyticsPackage.java
+++ b/android/src/main/java/com/evollu/react/fa/FIRAnalyticsPackage.java
@@ -24,7 +24,7 @@ public class FIRAnalyticsPackage implements ReactPackage {
         return modules;
     }
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker. This should be backwards compatible.