### PR TITLE
Added requiresMainQueueSetup

### DIFF
--- a/ios/RNFIRAnalytics.m
+++ b/ios/RNFIRAnalytics.m
@@ -7,6 +7,11 @@ RCT_EXPORT_MODULE()
 
 @synthesize bridge = _bridge;
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSDictionary<NSString *, id> *)constantsToExport
 {
   return nil;


### PR DESCRIPTION
Added requiresMainQueueSetup to prevent warning

_Module RNFIRAnalytics requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of._