### PR TITLE
Remove unnecessary method to suppress warning

### DIFF
--- a/ios/RNFIRAnalytics.m
+++ b/ios/RNFIRAnalytics.m
@@ -12,11 +12,6 @@ RCT_EXPORT_MODULE()
     return YES;
 }
 
-- (NSDictionary<NSString *, id> *)constantsToExport
-{
-  return nil;
-}
-
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];


### PR DESCRIPTION
This would suppress the following warning.

> YellowBox.js:80 Module RNFIRAnalytics requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

ref: https://github.com/wix/react-native-navigation/issues/1982